### PR TITLE
Add bottom margin to account for humidity text.

### DIFF
--- a/MMM-MyNest.css
+++ b/MMM-MyNest.css
@@ -198,6 +198,7 @@
   border-radius: 70px;
   font-size: 45px;
   line-height: 120px;
+  margin-bottom: 60px;
   border: none;
 }
 


### PR DESCRIPTION
Currently, the added humidity text at the bottom is not taken into account for the size of the entire module. Because of this, if modules are underneath this one you see something like:

<img width="428" alt="screen shot 2018-04-19 at 5 45 27 pm" src="https://user-images.githubusercontent.com/15267323/39020951-bc6229ec-43fc-11e8-972d-1977ad6fc46d.png">

The fix adds some bottom margin: 

<img width="357" alt="screen shot 2018-04-19 at 5 45 45 pm" src="https://user-images.githubusercontent.com/15267323/39020967-c971aee6-43fc-11e8-95f1-a9ce20bbda18.png">
